### PR TITLE
changed slack link to permanent invite

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
     </div>
 
     <div class="footer-col">
-        <p><a href="https://open-cv.slack.com"><i class="fa fa-slack"></i>Slack</a></p>
+        <p><a href="https://join.slack.com/t/open-cv/shared_invite/MjE1NTkxMDkzMzUwLTE1MDA0NTYxODMtYTc0NjE1NjI5OQ"><i class="fa fa-slack"></i>Slack</a></p>
         <p><a href="http://webchat.freenode.net/"><i class="fa fa-comments"></i>IRC #opencv</a></p>
     </div>
 


### PR DESCRIPTION
Slack channels need an invite, previous one was a 30 day one, that got lost. Now we got a permanent one. People clicking the logo on the main website will be able to join automatically now.